### PR TITLE
fix: installation guide markdown

### DIFF
--- a/installing.md
+++ b/installing.md
@@ -14,14 +14,14 @@ When you have installed, go to Documentation/Running
 Grab the source source code from git:
 
 * Maliit framework:
-{% highlight bash %}
+```bash
 git clone git@gitorious.org:maliit/maliit-framework.git
-{% endhighlight %}
+```
 
 * Maliit plugins (virtual keyboards etc.):
-{% highlight bash %}
+```bash
 git clone git@gitorious.org:maliit/maliit-plugins.git
-{% endhighlight %}
+```
 
 The installation order is
 * maliit-framework
@@ -29,11 +29,11 @@ The installation order is
 
 Maliit uses the qmake build system. So, to do a standard build and install, do:
 
-{% highlight bash %}
+```bash
 qmake
 make
 make install
-{% endhighlight %}
+```
 
 Run qmake HELP=1 to get more information about build options.
 
@@ -43,7 +43,7 @@ All components have a hard dependency on Qt 4.7
 
 ## From source code (Windows)
 
-Note: Windows support for Maliit is very experimental. Loading the IM plugins inside Maliit Server currently crashes: MALIIT#111
+Note: Windows support for Maliit is very experimental. Loading the IM plugins inside Maliit Server currently crashes: [MALIIT#111](https://github.com/maliit/keyboard/issues/111)
 
 These instructions require Maliit 0.90.1 or newer
 
@@ -56,31 +56,31 @@ These instructions require Maliit 0.90.1 or newer
 ### maliit-framework
 * Make sure that all the prerequisites exist in the PATH.
 * Use the following arguments to qmake:
-CONFIG+=disable-gconf CONFIG+=disable-dbus CONFIG+=nosdk CONFIG+=nodoc CONFIG+=notests PREFIX=C:/Maliit LIBDIR=C:/Maliit/bin
+`CONFIG+=disable-gconf CONFIG+=disable-dbus CONFIG+=nosdk CONFIG+=nodoc CONFIG+=notests PREFIX=C:/Maliit LIBDIR=C:/Maliit/bin`
 * Do qmake, make, make install
 
 ### maliit-plugins
 * Make sure that all the prerequisites exist in the PATH.
-* Make sure that PKG_CONFIG_PATH includes C:\Maliit\bin\pkgconfig (to find maliit-framework)
+* Make sure that `PKG_CONFIG_PATH` includes `C:\Maliit\bin\pkgconfig` (to find maliit-framework)
   Use the following arguments to qmake:
-  CONFIG+=notests PREFIX=C:/Maliit LIBDIR=C:/Maliit/bin
+  `CONFIG+=notests PREFIX=C:/Maliit LIBDIR=C:/Maliit/bin`
 * Do qmake, make, make install
 
-###Testing
+### Testing
 
 After having successfully built and installed both maliit-framework and plugins, you should now be able to run the provided example applications from C:\Maliit\bin, assuming the Qt libraries you built against are available in PATH:
 
-{% highlight bash %}
+```bash
 cd C:\Maliit\bin
 maliit-exampleapp-plainqt.exe
 maliit-keyboard-viewer.exe
-{% endhighlight %}
+```
 
 ## Official packages
 
 Note: Packaging is ongoing work.
 
-###Ubuntu
+### Ubuntu
 
 The Maliit Input Methods are not yet in any official Ubuntu repository. However, the packages are available through Launchpad. Daily builds of Maliit packages are in the maliit-team launchpad PPA.
 
@@ -88,26 +88,28 @@ To install the packages, you will need to add the maliit-team's PPA to your syst
 
 After addition and repository update, proceed with installation:
 
-{% highlight bash %}
+```bash
 sudo apt-get install maliit-framework maliit-plugins
-{% endhighlight %}
+```
 
 Or use any other graphical Ubuntu package installer to install the maliit-framework and maliit-plugins packages.
 
 Proceed to Documentation/Running
 
-###Fedora
+### Fedora
 
 Maliit packages are provided using Open Build Service (OBS) in project M17N:Maliit
 
 To install:
 
-* Download the appropriate .repo file from http://download.opensuse.org/repositories/M17N:/Maliit/ and save it as /etc/yum.repos.d/maliit.repo.
+* Download the appropriate .repo file from 
+  [http://download.opensuse.org/repositories/M17N:/Maliit/](http://download.opensuse.org/repositories/M17N:/Maliit/) 
+  and save it as `/etc/yum.repos.d/maliit.repo`.
 * Install the packages maliit-framework and "maliit-plugins with the Add/Remove Software application
 
 Proceed to Documentation/Running
 
-###openSUSE
+### openSUSE
 
 Maliit packages are provided using Open Build Service (OBS) in project M17N:Maliit
 
@@ -116,15 +118,16 @@ To install:
 * Download the appropriate files from http://download.opensuse.org/repositories/M17N:/Maliit/
 * Install the packages maliit-framework and "maliit-plugins with the Add/Remove Software application
 
-###Arch Linux
+### Arch Linux
 Packages (stable and git) are available in AUR
 
 To install:
 
-{%highlight bash %}
+```bash
 yaourt -S maliit-framework maliit-plugins
-{% endhighlight %}
-Substitute yaourt with your favorite AUR helper.
+```
+
+Substitute `yaourt` with your favorite AUR helper.
 
 Proceed to Documentation/Running
 


### PR DESCRIPTION
Before:
![before](https://github.com/maliit/maliit.github.io/assets/6796009/d36bbfab-cef6-454f-842f-73de81cff22c)

After: 
![after](https://github.com/maliit/maliit.github.io/assets/6796009/a4af1f68-21d9-46fc-b7c9-1148715b5604)

(ignore the differences due to me changing from a light to a dark theme)

Maybe you could test is the code blocks are still displayed correctly? I changed them to standard github-favoured markdown codeblocks